### PR TITLE
Replace importlib_metadata with importlib.metadata on Python 3.8+

### DIFF
--- a/pytest_checkdocs.py
+++ b/pytest_checkdocs.py
@@ -1,10 +1,15 @@
 import textwrap
 import contextlib
+import sys
 
 import pytest
 import docutils.core
-import importlib_metadata
 from more_itertools import first
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata as importlib_metadata
+else:
+    import importlib_metadata
 
 
 def pytest_collect_file(path, parent):

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
 	docutils >= 0.15
-	importlib_metadata >= 0.21
+	importlib_metadata >= 0.21; python_version<"3.8"
 	more_itertools
 setup_requires = setuptools_scm[toml] >= 3.4.1
 


### PR DESCRIPTION
As of Python3.8 importlib.metadata is the part of stdlib:
https://docs.python.org/3/whatsnew/3.8.html#new-modules
