### PR TITLE
drop troublesome pep517.meta usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
 	docutils >= 0.15
-	pep517
+	build >= 0.5.0
 	importlib_metadata >= 4
 setup_requires = setuptools_scm[toml] >= 3.4.1
 


### PR DESCRIPTION
pep517.meta.load will use pep517.meta.build, which tries to provision a
environment with pip. This is causing lots of issues in downstreams,
namely Arch Linux.
This patch replaces the pep517.meta usage with pypa/build, which can do
the same job without provisioning a isolated environment.

The drawback is that the PEP 517 dependencies will now have to be
present, which I feel is very reasonable.
Given a environment with all the required packages, we should not be
adding a dependency on the network to be able to run this plugin.

Signed-off-by: Filipe Laíns <lains@riseup.net>